### PR TITLE
download squish from froglogic

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -40,6 +40,9 @@ RUN apt-get update && apt-get install -y \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 
+### download squish
+RUN wget https://packages.froglogic.com/release/ff4ktzb2U77ts0EaseqFMw/1618552975/squish/6.7/squish-6.7.0-qt512x-linux64.run -O /opt/squish.run && chmod +x /opt/squish.run
+
 ### install current 'jq' explicitly
 RUN \
 { \
@@ -184,7 +187,6 @@ RUN \
         "${STARTUPDIR}/generate_container_user.sh" \
         "${STARTUPDIR}/vnc_startup.sh" \
         "${STARTUPDIR}/entrypoint.sh" \
-        "${STARTUPDIR}/squish.run" \
     && ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/hicolor
 

--- a/latest/src/startup/entrypoint.sh
+++ b/latest/src/startup/entrypoint.sh
@@ -3,7 +3,7 @@ export USER=headless
 
 /dockerstartup/vnc_startup.sh &
 
-/dockerstartup/squish.run unattended=1 ide=0 targetdir=${HOME}/squish licensekey=$LICENSEKEY
+/opt/squish.run unattended=1 ide=0 targetdir=${HOME}/squish licensekey=$LICENSEKEY
 
 cp ${HOME}/squish/etc/paths.ini ${HOME}/squish/etc/paths.ini-backup
 cp /dockerstartup/paths.ini ${HOME}/squish/etc/

--- a/latest/src/startup/squish.run
+++ b/latest/src/startup/squish.run
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed6513daefb613a96e5878048c6bd621ba9bc8d237dff7b061cc28333b44473b
-size 504565635


### PR DESCRIPTION
download squish from froglogic instead of keeping it in git
keeping it in git results of quota problems

I'm merging this PR without passing CI to get rid of the squish binary, otherwise  drone tries to do a "merge" and for that first gets the master branch and runs out of quota

![image](https://user-images.githubusercontent.com/2425577/114978703-50f7a280-9ea9-11eb-99f6-5ea453509bde.png)
