### PR TITLE
make container more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This container is not maintained nor used by froglogic, or the Qt company. It's 
 | CLIENT_REPO                | full path to the root of the client code | 
 | MIDDLEWARE_URL             | URL of the [testing middleware](https://github.com/owncloud/owncloud-test-middleware) |
 | BACKEND_HOST               | URL of the owncloud server |
+| SERVER_INI                 | full path of the `server.ini` file to be used |
 | SQUISH_PARAMETERS          | further [squishrunner cli parameters](https://doc.froglogic.com/squish/latest/rg-cmdline.html#rg-squishrunner-cli) |
 
 ## Acknowledgment

--- a/latest/src/startup/entrypoint.sh
+++ b/latest/src/startup/entrypoint.sh
@@ -9,7 +9,7 @@ cp ${HOME}/squish/etc/paths.ini ${HOME}/squish/etc/paths.ini-backup
 cp /dockerstartup/paths.ini ${HOME}/squish/etc/
 
 mkdir -p ${HOME}/.squish/ver1/
-cp /dockerstartup/server.ini ${HOME}/.squish/ver1/
+cp ${SERVER_INI} ${HOME}/.squish/ver1/
 
 /home/headless/squish/bin/squishserver &
 

--- a/latest/src/startup/entrypoint.sh
+++ b/latest/src/startup/entrypoint.sh
@@ -13,4 +13,4 @@ cp ${SERVER_INI} ${HOME}/.squish/ver1/
 
 /home/headless/squish/bin/squishserver &
 
-~/squish/bin/squishrunner --testsuite ${CLIENT_REPO}/test/gui/ --exitCodeOnFail 1
+~/squish/bin/squishrunner --testsuite ${CLIENT_REPO}/test/gui/ ${SQUISH_PARAMETERS} --exitCodeOnFail 1

--- a/latest/src/startup/entrypoint.sh
+++ b/latest/src/startup/entrypoint.sh
@@ -13,4 +13,4 @@ cp ${SERVER_INI} ${HOME}/.squish/ver1/
 
 /home/headless/squish/bin/squishserver &
 
-~/squish/bin/squishrunner --exitCodeOnFail 1 --testsuite ${CLIENT_REPO}/test/gui/
+~/squish/bin/squishrunner --testsuite ${CLIENT_REPO}/test/gui/ --exitCodeOnFail 1

--- a/latest/src/startup/server.ini
+++ b/latest/src/startup/server.ini
@@ -1,3 +1,0 @@
-[General]
-AUT/owncloud = "/tmp/client/client-build/bin"
-AUTPMTimeout = "15000"


### PR DESCRIPTION
- allow to copy any server.ini file => in drone runs we need different server.ini files
- move exitCodeOnFail option to the end => the order seems to be important
- allow optional parameters to be specified for squisrunner
