### PR TITLE
fix branch name in drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -160,7 +160,7 @@ def documentation(config):
         },
         'when': {
           'ref': [
-            'refs/heads/main',
+            'refs/heads/master',
           ],
         },
       },
@@ -168,7 +168,7 @@ def documentation(config):
     'depends_on': [],
     'trigger': {
       'ref': [
-        'refs/heads/main',
+        'refs/heads/master',
         'refs/tags/**',
         'refs/pull/**',
       ],


### PR DESCRIPTION
in this repo the main branch is called `master`
