### PR TITLE
tag container also with the squish version

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -114,6 +114,7 @@ def manifest(config):
           },
           'spec': '%s/manifest.tmpl' % config['path'],
           'ignore_missing': 'true',
+          'tags': '%s' % config['squishversion'],
         },
       },
     ],


### PR DESCRIPTION
to make it easy to go back to an older version anytime and make it possible to pin a specific squish version in CI

besides having a `latest` tag I want to have also a tag for every version, similar to selenium https://hub.docker.com/r/selenium/standalone-chrome-debug/tags?page=1&ordering=last_updated
