### PR TITLE
copy server.ini file to correct location even if the source has an other name

### DIFF
--- a/latest/src/startup/entrypoint.sh
+++ b/latest/src/startup/entrypoint.sh
@@ -9,7 +9,7 @@ cp ${HOME}/squish/etc/paths.ini ${HOME}/squish/etc/paths.ini-backup
 cp /dockerstartup/paths.ini ${HOME}/squish/etc/
 
 mkdir -p ${HOME}/.squish/ver1/
-cp ${SERVER_INI} ${HOME}/.squish/ver1/
+cp ${SERVER_INI} ${HOME}/.squish/ver1/server.ini
 
 /home/headless/squish/bin/squishserver &
 


### PR DESCRIPTION
make sure the final file is called `server.ini` even if the source has an other name

