### PR TITLE
Deploy libclloudproviders

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
         libcmocka-dev \
         qt5-default \
         qttools5-dev-tools \
+        libcloudproviders-dev \
         qt5keychain-dev \
         python-is-python3 \
     && apt-get -y autoremove \


### PR DESCRIPTION
```

11:42:18:701 Info: Starting AUT 'owncloud' with wrappers Qt: /drone/src/build-GUI-tests/bin/owncloud -s --logfile - --confdir /tmp/bdd-tests-owncloud-client/
/drone/src/build-GUI-tests/bin/owncloud: error while loading shared libraries: libcloudproviders.so.0: cannot open shared object file: No such file or directory
