### PR TITLE
set markdown-link-check to v 3.8.7

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -74,7 +74,7 @@ def documentation(config):
     'steps': [
       {
         'name': 'link-check',
-        'image': 'ghcr.io/tcort/markdown-link-check:stable',
+        'image': 'ghcr.io/tcort/markdown-link-check:3.8.7',
         'commands': [
           '/src/markdown-link-check README.md',
         ],


### PR DESCRIPTION
the newest version does not work for some reason, the old one is fine for us, so use it to fix CI
