### PR TITLE
use patched version of squish that suports examples in data tables

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -14,7 +14,7 @@ def main(ctx):
     'trigger': [],
     'repo': ctx.repo.name,
     'squishversion': {
-        'latest': '6.7.2-qt515x-linux64',
+        'latest': '6.7-20220106-1008-qt515x-linux64',
         'qt512': '6.7-20210421-1504-qt512x-linux64',
     },
     'description': 'Squish for ownCloud CI',


### PR DESCRIPTION
substitutions into a data table does not work with squish 6.7.x
this issue is solved in a custom build for us
