### PR TITLE
Disable screen auto-lock using autostart script

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-ARG BASETAG=21.04
+ARG BASETAG=22.04
 
 FROM ubuntu:${BASETAG} as stage-ubuntu
 # for squish download
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     nano \
+    ffmpeg \
     python3-gi \
     python3-nautilus \
     zlib1g-dev \

--- a/latest/src/home/config/autostart/disable-screensaver.desktop
+++ b/latest/src/home/config/autostart/disable-screensaver.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=disable-screensaver
+Comment=Disable screensaver
+Terminal=true
+Exec=xset s off


### PR DESCRIPTION
Disabling screen auto-lock was needed for the desktop client's GUI tests as sometimes the tests would fail due to auto locking, see https://github.com/owncloud/client/issues/9953.

Also, in this PR, I have updated the Ubuntu base image to `22.04`, an LTS version.