### PR TITLE
Revert to ubuntu 21.04 base image

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-ARG BASETAG=22.04
+ARG BASETAG=21.04
 
 FROM ubuntu:${BASETAG} as stage-ubuntu
 # for squish download


### PR DESCRIPTION
Currently, after upgrading base image to ubuntu 22.04, xfce4 is not working on other host ubuntu versions other than ubuntu 22.04.
This PR downgrades to version 21.04