### PR TITLE
Install missing gdb library

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -19,6 +19,7 @@ RUN yum install -y \
     qtkeychain-qt5-devel \
     libcloudproviders-devel \
     ffmpeg-free \
+    gdb \
     wget \
     hostname \
     nautilus-python\

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     nano \
     ffmpeg \
+    gdb \
     python3-gi \
     python3-nautilus \
     zlib1g-dev \


### PR DESCRIPTION
gdb is required by desktop-client GUI tests to read coredump files.

Closes https://github.com/owncloud-ci/squish/issues/37