### PR TITLE
Add gnome keyring

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -23,6 +23,7 @@ RUN yum install -y \
     wget \
     hostname \
     nautilus-python \
+    gnome-keyring \
     # to build python3
     openssl-devel \
     cairo-devel \
@@ -78,7 +79,7 @@ ENV \
 FROM stage-xfce as stage-vnc
 
 ### Bintray has been deprecated and disabled since 2021-05-01
-RUN wget -qO- https://github.com/accetto/tigervnc/releases/download/v1.10.1-mirror/tigervnc-1.10.1.x86_64.tar.gz | tar xz --strip 1 -C /
+RUN wget -qO- https://sourceforge.net/projects/tigervnc/files/stable/1.10.1/tigervnc-1.10.1.x86_64.tar.gz/download | tar xz --strip 1 -C /
 
 FROM stage-vnc as stage-novnc
 
@@ -168,6 +169,7 @@ RUN \
     "${STARTUPDIR}/generate_container_user.sh" \
     "${STARTUPDIR}/vnc_startup.sh" \
     "${STARTUPDIR}/entrypoint.sh" \
+    "${STARTUPDIR}/gnome-keyring.sh" \
     "/opt/squish.run" \
     && ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/*

--- a/fedora/src/home/config/autostart/gnome-keyring-daemon.desktop
+++ b/fedora/src/home/config/autostart/gnome-keyring-daemon.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=gnome-keyring-daemon
+Exec=/dockerstartup/gnome-keyring.sh

--- a/fedora/src/startup/gnome-keyring.sh
+++ b/fedora/src/startup/gnome-keyring.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gnome-keyring-daemon --start --components=secrets
+echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
+gnome-keyring-daemon -d --login

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y \
     nano \
     ffmpeg \
     gdb \
+    gnome-keyring \
     python3-gi \
     python3-nautilus \
     zlib1g-dev \
@@ -120,7 +121,7 @@ RUN apt-get update && apt-get install -y \
 FROM stage-xfce as stage-vnc
 
 ### Bintray has been deprecated and disabled since 2021-05-01
-RUN wget -qO- https://github.com/accetto/tigervnc/releases/download/v1.10.1-mirror/tigervnc-1.10.1.x86_64.tar.gz | tar xz --strip 1 -C /
+RUN wget -qO- https://sourceforge.net/projects/tigervnc/files/stable/1.10.1/tigervnc-1.10.1.x86_64.tar.gz/download | tar xz --strip 1 -C /
 
 FROM stage-vnc as stage-novnc
 
@@ -210,6 +211,7 @@ RUN \
     "${STARTUPDIR}/generate_container_user.sh" \
     "${STARTUPDIR}/vnc_startup.sh" \
     "${STARTUPDIR}/entrypoint.sh" \
+    "${STARTUPDIR}/gnome-keyring.sh" \
     "/opt/squish.run" \
     && ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/hicolor

--- a/latest/src/home/config/autostart/gnome-keyring-daemon.desktop
+++ b/latest/src/home/config/autostart/gnome-keyring-daemon.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=gnome-keyring-daemon
+Exec=/dockerstartup/gnome-keyring.sh

--- a/latest/src/startup/gnome-keyring.sh
+++ b/latest/src/startup/gnome-keyring.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gnome-keyring-daemon --start --components=secrets
+echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
+gnome-keyring-daemon -d --login

--- a/qt512/Dockerfile.amd64
+++ b/qt512/Dockerfile.amd64
@@ -12,35 +12,35 @@ LABEL maintainer="https://github.com/owncloud-ci"
 LABEL vendor="ownCloud GmbH"
 LABEL version="0.1"
 LABEL description="minimal Ubuntu with xfce4, VNC & squish to run GUI tests of the ownCloud desktop client in CI. \
- This container is not maintained nor used by froglogic or the Qt company. \
- It's not intended for public use but purely for CI runs."
+    This container is not maintained nor used by froglogic or the Qt company. \
+    It's not intended for public use but purely for CI runs."
 
 ### 'apt-get clean' runs automatically
 RUN apt-get update && apt-get install -y \
-        inetutils-ping \
-        lsb-release \
-        net-tools \
-        sudo \
-        unzip \
-        vim \
-        zip \
-        curl \
-        gdebi-core \
-        git \
-        wget \
-        nano \
-        python-gi \
-        python-nautilus \
-        zlib1g-dev \
-        libsqlite3-dev \
-        libssl-dev \
-        libcmocka-dev \
-        qt5-default \
-        qttools5-dev-tools \
-        libcloudproviders-dev \
-        qt5keychain-dev \
-        python-is-python3 \
-        gdb \
+    inetutils-ping \
+    lsb-release \
+    net-tools \
+    sudo \
+    unzip \
+    vim \
+    zip \
+    curl \
+    gdebi-core \
+    git \
+    wget \
+    nano \
+    python-gi \
+    python-nautilus \
+    zlib1g-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libcmocka-dev \
+    qt5-default \
+    qttools5-dev-tools \
+    libcloudproviders-dev \
+    qt5keychain-dev \
+    python-is-python3 \
+    gdb \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 
@@ -67,24 +67,24 @@ ENV \
 
 ### 'apt-get clean' runs automatically
 RUN apt-get update && apt-get install -y \
-        locales \
-        supervisor \
-        xfce4 \
-        xfce4-terminal \
-        xfce4-screenshooter \
-        mousepad \
-        ristretto \
+    locales \
+    supervisor \
+    xfce4 \
+    xfce4-terminal \
+    xfce4-screenshooter \
+    mousepad \
+    ristretto \
     && locale-gen en_US.UTF-8 \
     && apt-get purge -y \
-        pm-utils \
-        xscreensaver* \
+    pm-utils \
+    xscreensaver* \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 
 FROM stage-xfce as stage-vnc
 
 ### Bintray has been deprecated and disabled since 2021-05-01
-RUN wget -qO- https://github.com/accetto/tigervnc/releases/download/v1.10.1-mirror/tigervnc-1.10.1.x86_64.tar.gz | tar xz --strip 1 -C /
+RUN wget -qO- https://sourceforge.net/projects/tigervnc/files/stable/1.10.1/tigervnc-1.10.1.x86_64.tar.gz/download | tar xz --strip 1 -C /
 
 FROM stage-vnc as stage-novnc
 
@@ -97,7 +97,7 @@ ENV NO_VNC_HOME=/usr/share/usr/local/share/noVNCdim
 ### see https://github.com/ConSol/docker-headless-vnc-container/issues/50
 ### installed into '/usr/share/usr/local/share/noVNCdim'
 RUN apt-get update && apt-get install -y \
-        python-numpy \
+    python-numpy \
     && mkdir -p ${NO_VNC_HOME}/utils/websockify \
     && wget -qO- https://github.com/novnc/noVNC/archive/v1.2.0.tar.gz | tar xz --strip 1 -C ${NO_VNC_HOME} \
     && wget -qO- https://github.com/novnc/websockify/archive/v0.9.0.tar.gz | tar xz --strip 1 -C ${NO_VNC_HOME}/utils/websockify \
@@ -106,18 +106,18 @@ RUN apt-get update && apt-get install -y \
 
 ### add 'index.html' for choosing noVNC client
 RUN echo \
-"<!DOCTYPE html>\n" \
-"<html>\n" \
-"    <head>\n" \
-"        <title>noVNC</title>\n" \
-"        <meta charset=\"utf-8\"/>\n" \
-"    </head>\n" \
-"    <body>\n" \
-"        <p><a href=\"vnc_lite.html\">noVNC Lite Client</a></p>\n" \
-"        <p><a href=\"vnc.html\">noVNC Full Client</a></p>\n" \
-"    </body>\n" \
-"</html>" \
-> ${NO_VNC_HOME}/index.html
+    "<!DOCTYPE html>\n" \
+    "<html>\n" \
+    "    <head>\n" \
+    "        <title>noVNC</title>\n" \
+    "        <meta charset=\"utf-8\"/>\n" \
+    "    </head>\n" \
+    "    <body>\n" \
+    "        <p><a href=\"vnc_lite.html\">noVNC Lite Client</a></p>\n" \
+    "        <p><a href=\"vnc.html\">noVNC Full Client</a></p>\n" \
+    "    </body>\n" \
+    "</html>" \
+    > ${NO_VNC_HOME}/index.html
 
 FROM stage-novnc as stage-final
 
@@ -170,11 +170,11 @@ RUN \
     && adduser headless sudo \
     && echo "headless:$VNC_PW" | chpasswd \
     && chmod +x \
-        "${STARTUPDIR}/set_user_permissions.sh" \
-        "${STARTUPDIR}/generate_container_user.sh" \
-        "${STARTUPDIR}/vnc_startup.sh" \
-        "${STARTUPDIR}/entrypoint.sh" \
-        "/opt/squish.run" \
+    "${STARTUPDIR}/set_user_permissions.sh" \
+    "${STARTUPDIR}/generate_container_user.sh" \
+    "${STARTUPDIR}/vnc_startup.sh" \
+    "${STARTUPDIR}/entrypoint.sh" \
+    "/opt/squish.run" \
     && ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/hicolor
 


### PR DESCRIPTION
Added `gnome-keyring` keyring provider.

Test logs with:
 - image WITHOUT gnome-keyring
 ```
[ warning sync.credentials.http.legacy ]:	Migrating old keychain entries failed "The name org.freedesktop.secrets was not provided by any .service files"
```
- image WITH gnome-keyring
```
[ warning sync.credentials.http.legacy ]:	Migrating old keychain entries failed "Entry not found"
```