### PR TITLE
update squish to 7.1 with use qt6.4

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -24,7 +24,7 @@ def main(ctx):
     'arch': 'amd64',
     'repo': ctx.repo.name,
     'squishversion': {
-        'latest': '6.7-20220106-1008-qt515x-linux64',
+        'latest': '7.1.1-qt64x-linux64',
         'fedora': '7.1.1-qt64x-linux64',
         'qt512': '6.7-20210421-1504-qt512x-linux64',
     },

--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,7 @@ def main(ctx):
     'repo': ctx.repo.name,
     'squishversion': {
         'latest': '6.7-20220106-1008-qt515x-linux64',
-        'fedora': '6.7-20220106-1008-qt515x-linux64',
+        'fedora': 'squish-7.1.1-qt64x-linux64',
         'qt512': '6.7-20210421-1504-qt512x-linux64',
     },
     'description': 'Squish for ownCloud CI',

--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,7 @@ def main(ctx):
     'repo': ctx.repo.name,
     'squishversion': {
         'latest': '6.7-20220106-1008-qt515x-linux64',
-        'fedora': 'squish-7.1.1-qt64x-linux64',
+        'fedora': '7.1.1-qt64x-linux64',
         'qt512': '6.7-20210421-1504-qt512x-linux64',
     },
     'description': 'Squish for ownCloud CI',

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -13,10 +13,10 @@ LABEL description="minimal Fedora with xfce4, VNC & squish to run GUI tests of t
     It's not intended for public use but purely for CI runs."
 
 RUN yum install -y \
-    qt5-qtbase-devel \
-    qt5-qttools-devel \
-    qt5-qtsvg \
-    qtkeychain-qt5-devel \
+    qt6-qtbase-devel-6.4.3 \
+    qt6-qttools-devel-6.4.3 \
+    qt6-qtsvg-6.4.3 \
+    qtkeychain-qt6-devel \
     libcloudproviders-devel \
     ffmpeg-free \
     gdb \
@@ -35,17 +35,17 @@ RUN yum install -y \
     && yum autoremove -y \
     && yum clean all
 
-### install Python 3.8 including needed modules
+### install Python 3.10 including needed modules
 RUN mkdir /python && \
     cd /python && \
-    wget -O-  https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz | tar xz --strip 1 -C . && \
+    wget -O-  https://www.python.org/ftp/python/3.10.12/Python-3.10.12.tgz | tar xz --strip 1 -C . && \
     ./configure --enable-optimizations --enable-shared --prefix=/usr/local LDFLAGS="-Wl,-rpath /usr/local/lib" && \
     make && \
     sudo make install && \
     cp /python/libpython* /usr/lib && \
-    python3.8 -m pip install requests && \
-    python3.8 -m pip install pycairo && \
-    python3.8 -m pip install PyGObject && \
+    python3.10 -m pip install requests && \
+    python3.10 -m pip install pycairo && \
+    python3.10 -m pip install PyGObject && \
     rm -rf /python
 
 FROM stage-fedora as stage-xfce

--- a/fedora/src/startup/paths.ini
+++ b/fedora/src/startup/paths.ini
@@ -1,5 +1,5 @@
 [Interpreter]
-PythonPluginVersion = "3.8"
+PythonPluginVersion = "3.10"
 
 [Paths]
 LibraryPath = "@(SQUISH_PREFIX)/lib:@(SQUISH_PREFIX)/perl/lib/perl5/5.22.0/x86_64-linux/CORE:/usr:@(SQUISH_PREFIX)/ruby/lib:@(SQUISH_PREFIX)/tcl/lib"


### PR DESCRIPTION
Updated Squish to 7.1.1 with Qt6.4 and Python to 3.10 required by Squish.
Depends on https://github.com/owncloud-ci/client/pull/27

Tested: https://drone.owncloud.com/owncloud/client/16291 :heavy_check_mark: 