### PR TITLE
Add gnome-keyring lib to store secrets

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -17,7 +17,6 @@ RUN yum install -y \
     qt6-qttools-devel-6.4.3 \
     qt6-qtsvg-6.4.3 \
     qtkeychain-qt6-devel \
-    libcloudproviders-devel \
     ffmpeg-free \
     gdb \
     wget \

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -22,6 +22,7 @@ RUN yum install -y \
     gdb \
     wget \
     hostname \
+    gnome-keyring \
     nautilus-python \
     # to build python3
     openssl-devel \
@@ -168,6 +169,7 @@ RUN \
     "${STARTUPDIR}/generate_container_user.sh" \
     "${STARTUPDIR}/vnc_startup.sh" \
     "${STARTUPDIR}/entrypoint.sh" \
+    "${STARTUPDIR}/gnome-keyring" \
     "/opt/squish.run" \
     && ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/*

--- a/fedora/src/home/config/autostart/gnome-kerying.desktop
+++ b/fedora/src/home/config/autostart/gnome-kerying.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=gnome-keyring-daemon
+Exec=/dockerstartup/gnome-keyring

--- a/fedora/src/startup/gnome-keyring
+++ b/fedora/src/startup/gnome-keyring
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gnome-keyring-daemon --start --components=pkcs11,secrets,ssh
+echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
+gnome-keyring-daemon -d --login


### PR DESCRIPTION
Added `gnome-keyring` library. We need it to store secrets during the Squish tests so that tests related to restarting work as expected.

Quit and restart client in GUI test works: https://drone.owncloud.com/owncloud/client/16805/1/14

Fixes https://github.com/owncloud/client/issues/11290