### PR TITLE
build: remove unnecessary lib install

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -13,10 +13,7 @@ LABEL description="minimal Fedora with xfce4, VNC & squish to run GUI tests of t
     It's not intended for public use but purely for CI runs."
 
 RUN yum install -y \
-    qt6-qtbase-devel-6.4.3 \
-    qt6-qttools-devel-6.4.3 \
     qt6-qtsvg-6.4.3 \
-    qtkeychain-qt6-devel \
     ffmpeg-free \
     gdb \
     wget \
@@ -70,11 +67,6 @@ RUN yum install -y \
     && yum autoremove -y \
     && yum clean all
 
-ENV \
-    LANG='en_US.UTF-8' \
-    LANGUAGE='en_US:en' \
-    LC_ALL='en_US.UTF-8'
-
 FROM stage-xfce as stage-vnc
 
 ### Bintray has been deprecated and disabled since 2021-05-01
@@ -110,6 +102,10 @@ RUN yum install -y python3-numpy \
     > ${NO_VNC_HOME}/index.html
 
 FROM stage-novnc as stage-final
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # for squish download
 ARG S3SECRET


### PR DESCRIPTION
remove unnecessary lib install and rebuild image with updated `owncloudci/client`
Requires https://github.com/owncloud-ci/client/pull/28