### PR TITLE
fix: unlock keyring in xstartup

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -216,8 +216,7 @@ RUN \
     "${STARTUPDIR}/set_user_permissions.sh" \
     "${STARTUPDIR}/generate_container_user.sh" \
     "${STARTUPDIR}/vnc_startup.sh" \
-    "${STARTUPDIR}/entrypoint.sh" \
-    "${STARTUPDIR}/gnome-keyring"
+    "${STARTUPDIR}/entrypoint.sh"
 
 RUN ${ARG_SUPPORT_USER_GROUP_OVERRIDE/*/chmod a+w /etc/passwd /etc/group} \
     && gtk-update-icon-cache -f /usr/share/icons/* \

--- a/fedora/src/home/config/autostart/gnome-kerying.desktop
+++ b/fedora/src/home/config/autostart/gnome-kerying.desktop
@@ -1,4 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=gnome-keyring-daemon
-Exec=/dockerstartup/gnome-keyring

--- a/fedora/src/startup/gnome-keyring
+++ b/fedora/src/startup/gnome-keyring
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-gnome-keyring-daemon --start --components=pkcs11,secrets,ssh
-echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
-gnome-keyring-daemon -d --login

--- a/fedora/src/startup/vnc_startup.sh
+++ b/fedora/src/startup/vnc_startup.sh
@@ -100,7 +100,13 @@ if [[ ! -f "${XSTARTUP_FILE}" ]]; then
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
 
-dbus-launch --exit-with-session startxfce4 &
+eval $(dbus-launch --sh-syntax --exit-with-session)
+
+gnome-keyring-daemon --start --components=pkcs11,secrets,ssh
+echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
+gnome-keyring-daemon -d --login
+
+startxfce4 &
 EOF
 fi
 


### PR DESCRIPTION
GUI tests can fail due to unreliable unlocking of keyring: https://github.com/owncloud/client/issues/11619

So, unlock of keyring is now done in a `xstartup` file. This seems pretty reliable.

Tested builds:
- https://drone.owncloud.com/owncloud/client/18969
- https://drone.owncloud.com/owncloud/client/18970
- https://drone.owncloud.com/owncloud/client/18971
- https://drone.owncloud.com/owncloud/client/18972