### PR TITLE
build: export dbus session address to squishrunner context

### DIFF
--- a/fedora/src/startup/entrypoint.sh
+++ b/fedora/src/startup/entrypoint.sh
@@ -40,6 +40,21 @@ export SQUISH_NO_CRASHHANDLER=1
 
 (/home/headless/squish/bin/squishserver >>"${GUI_TEST_REPORT_DIR}"/serverlog.log 2>&1) &
 
+# set DBUS_SESSION_BUS_ADDRESS for squishrunner terminal session
+DBUS_SESSION_FILE=/tmp/dbus_env.sh
+if [ -f $DBUS_SESSION_FILE ]; then
+  source $DBUS_SESSION_FILE
+else
+  timeout=10 # seconds
+  echo "[ERROR] 'DBUS_SESSION_BUS_ADDRESS' not set. Waiting for $timeout seconds..."
+  sleep $timeout
+  if [ -f $DBUS_SESSION_FILE ]; then
+    echo "[TIMEOUT] 'DBUS_SESSION_BUS_ADDRESS' still not set after $timeout seconds. Exiting..."
+    exit 1
+  fi
+  source $DBUS_SESSION_FILE
+fi
+
 # squishrunner waits itself for a license to become available, but fails with error 37 if it cannot connect to the license server
 LICENSE_ERROR_RESULT_CODE=37
 result=LICENSE_ERROR_RESULT_CODE

--- a/fedora/src/startup/vnc_startup.sh
+++ b/fedora/src/startup/vnc_startup.sh
@@ -106,6 +106,9 @@ gnome-keyring-daemon --start --components=pkcs11,secrets,ssh
 echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
 gnome-keyring-daemon -d --login
 
+# save dbus session address
+echo "export DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}" >> /tmp/dbus_env.sh
+
 startxfce4 &
 EOF
 fi


### PR DESCRIPTION
Since, vnc and squishrunner are running in different session, the dbus session address env is not available for squishrunner.
Make `DBUS_SESSION_BUS_ADDRESS` available to squishrunner terminal session.

Required for GUI tests:
- https://github.com/owncloud/client/issues/11883
- https://github.com/owncloud/client/pull/11866