### PR TITLE
build: remove unnecessary keyring command

### DIFF
--- a/fedora/src/startup/vnc_startup.sh
+++ b/fedora/src/startup/vnc_startup.sh
@@ -104,7 +104,6 @@ eval $(dbus-launch --sh-syntax --exit-with-session)
 
 gnome-keyring-daemon --start --components=pkcs11,secrets,ssh
 echo -n "${VNC_PW}" | gnome-keyring-daemon -r --unlock
-gnome-keyring-daemon -d --login
 
 # save dbus session address
 echo "export DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}" >> /tmp/dbus_env.sh


### PR DESCRIPTION
Command `gnome-keyring-daemon -d --login` is not necessary for headless container