### PR TITLE
build: add missing libxcrypt-compat package

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -70,6 +70,7 @@ ENV CLIENT_BUILD_TARGET=${ARG_CLIENT_BUILD_TARGET:-linux-gcc-x86_64-squish}
 
 RUN dnf install -y --setopt=install_weak_deps=False \
     procps-ng \
+    libxcrypt-compat \
     # to build client
     libEGL-devel \
     gcc-c++ \


### PR DESCRIPTION
`libxcrypt-compat` is required for squish installation. if the package is missing, squish installation fails.