### PR TITLE
feat: get image base tag from arg

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,21 +1,13 @@
+"""
+This config defines the Drone CI pipelines for building and publishing Squish images for ownCloud CI.
+"""
+
+versions = {
+  # <base_image>: <base_image_tag>
+  'fedora': '42',
+}
+
 def main(ctx):
-  versions = [
-    'fedora',
-  ]
-
-  arches = [
-    'amd64',
-  ]
-
-  # image's base version
-  # For example, in latest's Dockerfile;
-  #   FROM ubuntu:22.04
-  # then,
-  #   'latest': '22.04'
-  base_img_tag = {
-    'fedora': ['fedora', '42'],
-  }
-
   config = {
     'version': 'latest',
     'arch': 'amd64',
@@ -25,29 +17,25 @@ def main(ctx):
     },
     'description': 'Squish for ownCloud CI',
     's3secret': {
-       'from_secret': 'squish_download_s3secret',
+        'from_secret': 'squish_download_s3secret',
     },
   }
 
   stages = []
-  for version in versions:
+  for version, base_img_tag in versions.items():
     config['version'] = version
+    config['base_image_tag'] = base_img_tag
 
     if config['version'] == 'latest':
       config['path'] = 'latest'
     else:
-      config['path'] = '%s' % config['version']
+      config['path'] = config['version']
 
     config['tags'] = [config['version']]
-    if config['version'] == 'latest':
-      config['tags'].append('%s-%s' % (base_img_tag[config['version']][0], config['squishversion'][config['version']]))
-    else:
-      config['tags'].append('%s-%s' % (config['version'], config['squishversion'][config['version']]))
-    if config['version'] in base_img_tag:
-      config['tags'].append(
-        '%s-%s-%s' % (base_img_tag[config['version']][0], base_img_tag[config['version']][1], config['squishversion'][config['version']])
-      )
-
+    config['tags'].append('%s-%s' % (config['version'], config['squishversion'][config['version']]))
+    config['tags'].append(
+      '%s-%s-%s' % (config['version'], base_img_tag, config['squishversion'][config['version']])
+    )
 
     stages.append(docker(config))
 
@@ -188,6 +176,7 @@ def dryrun(config):
       'context': config['path'],
       'build_args': [
         'SQUISHVERSION=%s' % config['squishversion'][config['version']],
+        'BASETAG=%s' % config['base_image_tag'],
       ],
       'build_args_from_env': [
         'S3SECRET'
@@ -221,6 +210,7 @@ def publish(config):
       'pull_image': False,
       'build_args': [
         'SQUISHVERSION=%s' % config['squishversion'][config['version']],
+        'BASETAG=%s' % config['base_image_tag'],
       ],
       'build_args_from_env': [
         'S3SECRET'

--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -1,5 +1,5 @@
 ARG BASE=fedora
-ARG BASETAG=42
+ARG BASETAG
 
 FROM ${BASE}:${BASETAG} AS stage-build
 


### PR DESCRIPTION
Provide `BASETAG` the arg value while building the image. This helps to prevent the need for changing base image tag in multiple lines. Also, this ensures that the final image tag name always contains the desired base image tag. E.g.: `fedora-42-xyz...`