### PR TITLE
add env to skip test run

### DIFF
--- a/fedora/Dockerfile.amd64
+++ b/fedora/Dockerfile.amd64
@@ -8,7 +8,9 @@ ARG ARG_CLIENT_BUILD_TARGET
 
 ENV OWNBUILD_DIR=/ownbuild
 ENV CLIENT_BRANCH=${ARG_CLIENT_BRANCH:-master}
-ENV CLIENT_BUILD_TARGET=${ARG_CLIENT_BUILD_TARGET:-linux-64-gcc-debug}
+ENV CLIENT_BUILD_TARGET=${ARG_CLIENT_BUILD_TARGET:-linux-64-gcc}
+ENV CFLAGS="-std=gnu89"
+ENV CXXFLAGS="-std=gnu++98"
 
 RUN dnf install -y \
     git-core \
@@ -92,7 +94,7 @@ ENV LC_ALL=C.UTF-8
 ENV FONTCONFIG_PATH=/etc/fonts
 ENV OWNBUILD_DIR=/ownbuild
 ENV CLIENT_BRANCH=${ARG_CLIENT_BRANCH:-master}
-ENV CLIENT_BUILD_TARGET=${ARG_CLIENT_BUILD_TARGET:-linux-64-gcc-debug}
+ENV CLIENT_BUILD_TARGET=${ARG_CLIENT_BUILD_TARGET:-linux-64-gcc}
 
 RUN dnf install -y --setopt=install_weak_deps=False \
     procps-ng \
@@ -253,5 +255,8 @@ ARG ARG_VERSION_STICKER
 ENV \
     REFRESHED_AT=${ARG_REFRESHED_AT} \
     VERSION_STICKER=${ARG_VERSION_STICKER}
+
+# Enable or disable gui test run
+ENV SKIP_TEST_RUN=false
 
 ENTRYPOINT [ "/dockerstartup/entrypoint.sh" ]

--- a/fedora/src/startup/entrypoint.sh
+++ b/fedora/src/startup/entrypoint.sh
@@ -90,22 +90,6 @@ endtime=$(date -ud "$runtime" +%s)
 # start squishserver
 (${HOME}/squish/bin/squishserver >>"${GUI_TEST_REPORT_DIR}"/serverlog.log 2>&1) &
 
-# squishrunner waits itself for a license to become available, but fails with error 37 if it cannot connect to the license server
-LICENSE_ERROR_RESULT_CODE=37
-result=0
-echo "[SQUISH] Starting tests..."
-while true; do
-  if [[ $(date -u +%s) -gt $endtime ]]; then
-    echo "[SQUISH] Timeout waiting for license server"
-    exit 1
-  fi
-
-  ${HOME}/squish/bin/squishrunner ${SQUISH_PARAMETERS} --reportgen stdout --exitCodeOnFail 1
-  result=$?
-  if [[ $result -eq $LICENSE_ERROR_RESULT_CODE ]]; then
-    echo "[SQUISH] Waiting for license server"
-    sleep $((1 + $RANDOM % 30))
-  else
-    exit $result
-  fi
-done
+if [ "$SKIP_TEST_RUN" == "false" ]; then
+  "${STARTUPDIR}"/run_test.sh
+fi

--- a/fedora/src/startup/run_test.sh
+++ b/fedora/src/startup/run_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# squishrunner waits itself for a license to become available, but fails with error 37 if it cannot connect to the license server
+LICENSE_ERROR_RESULT_CODE=37
+result=0
+echo "[SQUISH] Starting tests..."
+while true; do
+  if [[ $(date -u +%s) -gt $endtime ]]; then
+    echo "[SQUISH] Timeout waiting for license server"
+    exit 1
+  fi
+
+  ${HOME}/squish/bin/squishrunner ${SQUISH_PARAMETERS} --reportgen stdout --exitCodeOnFail 1
+  result=$?
+  if [[ $result -eq $LICENSE_ERROR_RESULT_CODE ]]; then
+    echo "[SQUISH] Waiting for license server"
+    sleep $((1 + $RANDOM % 30))
+  else
+    exit $result
+  fi
+done


### PR DESCRIPTION
### Description
Added env `SKIP_TEST_RUN` to skip test. This will help to separate setting up squish and running the gui tests.